### PR TITLE
Changes related to skipping LPC cycles different than I/O or TPM

### DIFF
--- a/lpc_defines.v
+++ b/lpc_defines.v
@@ -61,6 +61,8 @@
 `define LPC_ST_SYNC_WR          5'h16   // LPC Sync State (write, may be multiple cycles for wait-states)
 `define LPC_ST_FINAL_TAR_CLK1   5'h17   // LPC Turnaround (final, 1st cycle)
 `define LPC_ST_FINAL_TAR_CLK2   5'h18   // LPC Turnaround (final, 2nd cycle)
+`define LPC_ST_CYCTYPE_MEMORY_RD   5'h19  //LPC Memory Read (new)
+`define LPC_ST_CYCTYPE_MEMORY_WR   5'h1A  //LPC Memory Write (new)
 
 `define WB_SEL_BYTE     4'b0001             // Byte Transfer
 `define WB_SEL_SHORT    4'b0011             // Short Transfer

--- a/lpc_periph.v
+++ b/lpc_periph.v
@@ -146,7 +146,7 @@ module lpc_periph (clk_i, nrst_i, lframe_i, lad_bus, addr_hit_i, current_state_o
                   if ((lframe_i == 1'b0) && (lad_bus == 4'h0)) fsm_next_state <= `LPC_ST_START;
                   else if ((lframe_i == 1'b1) && (lad_bus != 4'h0) && (lad_bus != 4'h2)) skipCycle = 1'b1;
                   else if ((lframe_i == 1'b1) && (lad_bus == 4'h0)) fsm_next_state <= `LPC_ST_CYCTYPE_RD;
-                  else if ((lframe_i == 1'b1) && (lad_bus == 4'h2)) fsm_next_state <= `LPC_ST_CYCTYPE_WR;                
+                  else if ((lframe_i == 1'b1) && (lad_bus == 4'h2)) fsm_next_state <= `LPC_ST_CYCTYPE_WR;
               end
               `LPC_ST_CYCTYPE_RD:
                fsm_next_state <= `LPC_ST_ADDR_RD_CLK1;

--- a/lpc_periph_tb.v
+++ b/lpc_periph_tb.v
@@ -59,7 +59,8 @@ module lpc_periph_tb();
     wire        READYNET;
     reg  [15:0] u_addr;    //auxiliary host addres
     reg   [7:0] u_data;    //auxiliary host data
-    integer i;
+    integer i, j;
+    reg memory_cycle_sig;
 
     initial
     begin
@@ -82,6 +83,8 @@ module lpc_periph_tb();
         wr_flag = 1;
         #40 nrst_i = 0;
         #250 nrst_i = 1;
+        
+        memory_cycle_sig = 0;
 
         // Perform write
         #40  lframe_i = 0;
@@ -117,6 +120,8 @@ module lpc_periph_tb();
         #250 nrst_i = 1;
 
         for (i = 0; i <= 128; i = i + 1) begin
+          for(j = 0; j < 2; j = j + 1) begin
+            memory_cycle_sig = j; //Cycle type: Memory or I/O
             // Perform write
             #40  lframe_i  = 0;
             rd_flag = 0;
@@ -135,7 +140,8 @@ module lpc_periph_tb();
 
             #250 nrst_i = 1;
             #400 lframe_i = 1;
-        end;
+          end   
+        end
 
         #8000;
         //------------------------------
@@ -153,6 +159,7 @@ module lpc_periph_tb();
     .ctrl_lframe_i(lframe_i),
     .ctrl_rd_status_i(rd_flag),
     .ctrl_wr_status_i(wr_flag),
+    .ctrl_memory_cycle_i(memory_cycle_sig),
     // Output to GPIO
     .ctrl_data_o(host_data_o),
     .ctrl_ready_o(host_ready),


### PR DESCRIPTION
Changes related to skipping in "LPC Peripheral" LPC cycles are different than I/O or TPM cycles.

Signed-off-by: Maciej Gabryelski <maciej.gabryelski@3mdeb.com>